### PR TITLE
WIP: Add support objects with #toJS defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ Yolk.createElement(
 
 Without this pragma, Babel will assume that you mean to write JSX for React and you will receive `React is undefined` errors.
 
+## Support for Immutable Objects and #toJS
+
+Yolk will not attempt to 'unwrap' objects that have a `toJS` function defined on them. This method is only called when a plain
+value is required to render something. It is particularly useful when used with libraries like
+[Immutable.js](https://github.com/facebook/immutable-js/) or [Freezer.js](https://github.com/arqex/freezer).
+
 ## Supported Events
 
 Yolk supports the following list of standard browser events:

--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -6,6 +6,7 @@ const patch = require(`virtual-dom/patch`)
 const flatten = require(`lodash.flattendeep`)
 const wrapObject = require(`./wrapObject`)
 const transformProperties = require(`./transformProperties`)
+const transformChildren = require(`./transformChildren`)
 const isFunction = require(`./isFunction`)
 const CustomEvent = require(`./CustomEvent`)
 
@@ -44,8 +45,8 @@ YolkBaseComponent.prototype = {
 
     this._childSubject = new Rx.BehaviorSubject(this._children)
 
-    const propObservable = wrapObject(propsSubject).map(props => transformProperties(this.id, props))
-    const childObservable = this._childSubject.flatMapLatest(wrapObject)
+    const propObservable = wrapObject(propsSubject).map(transformProperties)
+    const childObservable = this._childSubject.flatMapLatest(wrapObject).map(transformChildren)
 
     const vNode = h(this.id)
     this.node = create(vNode)

--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -60,7 +60,7 @@ YolkBaseComponent.prototype = {
         (err) => {throw new Error(err.message)}
       )
 
-    isFunction(this._props.onMount) && this.onMount()
+    this.onMount()
 
     return this.node
   },
@@ -98,10 +98,10 @@ YolkBaseComponent.prototype = {
 
   onUnmount () {
     const {onMount, onUnmount} = this._props
+    const event = new CustomEvent(`unmount`)
+    this.node.dispatchEvent(event)
 
     if (isFunction(onUnmount)) {
-      const event = new CustomEvent(`unmount`)
-      this.node.dispatchEvent(event)
       this.node.removeEventListener(`unmount`, onUnmount)
     }
 

--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -60,7 +60,7 @@ YolkBaseComponent.prototype = {
         (err) => {throw new Error(err.message)}
       )
 
-    this.onMount()
+    this.emitMount()
 
     return this.node
   },
@@ -83,7 +83,7 @@ YolkBaseComponent.prototype = {
   },
 
   destroy () {
-    this.onUnmount()
+    this.emitUnmount()
     this._patchSubscription.dispose()
 
     const children = this._children
@@ -96,7 +96,7 @@ YolkBaseComponent.prototype = {
     }
   },
 
-  onUnmount () {
+  emitUnmount () {
     const {onMount, onUnmount} = this._props
     const event = new CustomEvent(`unmount`)
     this.node.dispatchEvent(event)
@@ -110,12 +110,12 @@ YolkBaseComponent.prototype = {
     }
   },
 
-  onMount () {
+  emitMount () {
     if (this.node.parentNode) {
       const event = new CustomEvent(`mount`)
       this.node.dispatchEvent(event)
     } else {
-      setTimeout(() => this.onMount(), 0)
+      setTimeout(() => this.emitMount(), 0)
     }
   },
 }

--- a/src/YolkBaseComponent.js
+++ b/src/YolkBaseComponent.js
@@ -46,7 +46,7 @@ YolkBaseComponent.prototype = {
     this._childSubject = new Rx.BehaviorSubject(this._children)
 
     const propObservable = wrapObject(propsSubject).map(transformProperties)
-    const childObservable = this._childSubject.flatMapLatest(wrapObject).map(transformChildren)
+    const childObservable = this._childSubject.flatMapLatest(wrapObject).flatMapLatest(transformChildren)
 
     const vNode = h(this.id)
     this.node = create(vNode)

--- a/src/hasToJS.js
+++ b/src/hasToJS.js
@@ -1,0 +1,5 @@
+const isFunction = require(`./isFunction`)
+
+module.exports = function hasToJS (obj) {
+  return !!obj && isFunction(obj.toJS)
+}

--- a/src/transformChildren.js
+++ b/src/transformChildren.js
@@ -1,3 +1,5 @@
+const hasToJS = require(`./hasToJS`)
+
 module.exports = function transformChildren (children) {
-  return children
+  return hasToJS(children) ? children.toJS() : children
 }

--- a/src/transformChildren.js
+++ b/src/transformChildren.js
@@ -1,5 +1,7 @@
+const wrapObject = require(`./wrapObject`)
 const hasToJS = require(`./hasToJS`)
 
 module.exports = function transformChildren (children) {
-  return hasToJS(children) ? children.toJS() : children
+  const _children = hasToJS(children) ? children.toJS() : children
+  return wrapObject(_children)
 }

--- a/src/transformChildren.js
+++ b/src/transformChildren.js
@@ -1,0 +1,3 @@
+module.exports = function transformChildren (children) {
+  return children
+}

--- a/src/transformProperties.js
+++ b/src/transformProperties.js
@@ -1,8 +1,9 @@
 const DOMProperties = require(`./DOMProperties`)
 const transformStyle = require(`./transformStyle`)
 const transformProperty = require(`./transformProperty`)
+const hasToJS = require(`./hasToJS`)
 
-module.exports = function transformProperties (tag, props) {
+module.exports = function transformProperties (props) {
   const keys = Object.keys(props)
   const length = keys.length
   const newProps = {attributes: {}}
@@ -10,10 +11,11 @@ module.exports = function transformProperties (tag, props) {
 
   while (++i < length) {
     const key = keys[i]
-    const value = props[key]
+    let value = props[key]
+    value = hasToJS(value) ? value.toJS() : value
 
     if (key === `style`) {
-      transformStyle(newProps, props.style)
+      transformStyle(newProps, value)
     } else {
       transformProperty(newProps, key, value, DOMProperties[key])
     }

--- a/src/transformProperty.js
+++ b/src/transformProperty.js
@@ -16,14 +16,13 @@ const EMPTY_PROP = {
   hasBooleanValue: false,
 }
 
-module.exports = function transformProperty (props, key, value, property) {
-  const _property = property || EMPTY_PROP
+module.exports = function transformProperty (props, key, value, property = EMPTY_PROP) {
   let isDataAttribute = false
   let _value = value
   let _key
 
-  if (_property.isStandard) {
-    _key = _property.computed
+  if (property.isStandard) {
+    _key = property.computed
   } else {
     isDataAttribute = IS_DATA_MATCHER.test(key)
 
@@ -32,21 +31,21 @@ module.exports = function transformProperty (props, key, value, property) {
     }
   }
 
-  if (_property.canBeArrayOfStrings && Array.isArray(value)) {
+  if (property.canBeArrayOfStrings && Array.isArray(value)) {
     _value = compact(value).join(` `)
-  } else if (_property.hasBooleanValue && !value) {
+  } else if (property.hasBooleanValue && !value) {
     return props
   }
 
-  if (_property.isAttribute || isDataAttribute) {
+  if (property.isAttribute || isDataAttribute) {
     props.attributes[_key] = _value
-  } else if (_property.usePropertyHook) {
+  } else if (property.usePropertyHook) {
     props[_key] = new SoftSetHook(_value)
-  } else if (_property.useCustomEventHook) {
+  } else if (property.useCustomEventHook) {
     props[_key] = new CustomEventHook(_key, _value)
-  } else if (_property.useAttributeHook) {
+  } else if (property.useAttributeHook) {
     props[_key] = new AttributeHook(_value)
-  } else if (_property.isStandard) {
+  } else if (property.isStandard) {
     props[_key] = _value
   }
 

--- a/src/wrapObject.js
+++ b/src/wrapObject.js
@@ -1,11 +1,14 @@
 const Rx = require(`rx`)
 const isPlainObject = require(`lodash.isplainobject`)
 const isObservable = require(`./isObservable`)
+const isFunction = require(`./isFunction`)
 const isEmpty = require(`./isEmpty`)
 
 module.exports = function wrapObject (obj) {
   if (isObservable(obj)) {
     return obj.flatMapLatest(wrapObject)
+  } else if (obj && isFunction(obj.toJS)) {
+    // fall through if `toJS` is defined
   } else if (isPlainObject(obj) && !isEmpty(obj)) {
     const keys = Object.keys(obj)
     const length = keys.length

--- a/src/wrapObject.js
+++ b/src/wrapObject.js
@@ -1,13 +1,13 @@
 const Rx = require(`rx`)
 const isPlainObject = require(`lodash.isplainobject`)
 const isObservable = require(`./isObservable`)
-const isFunction = require(`./isFunction`)
 const isEmpty = require(`./isEmpty`)
+const hasToJS = require(`./hasToJS`)
 
 module.exports = function wrapObject (obj) {
   if (isObservable(obj)) {
     return obj.flatMapLatest(wrapObject)
-  } else if (obj && isFunction(obj.toJS)) {
+  } else if (hasToJS(obj)) {
     // fall through if `toJS` is defined
   } else if (isPlainObject(obj) && !isEmpty(obj)) {
     const keys = Object.keys(obj)

--- a/test/unit/YolkBaseComponent-test.js
+++ b/test/unit/YolkBaseComponent-test.js
@@ -1,0 +1,49 @@
+const test = require(`tape`)
+const YolkBaseComponent = require(`YolkBaseComponent`)
+
+test(`returns a base component`, t => {
+  t.plan(2)
+
+  const instance = new YolkBaseComponent(`p`, {height: 5}, [])
+  const node = instance.init()
+
+  t.equal(node.outerHTML, `<p height="5"></p>`)
+
+  const patched = new YolkBaseComponent(`p`, {height: 10}, [`hello`])
+  patched.update(instance)
+
+  t.equal(node.outerHTML, `<p height="10">hello</p>`)
+})
+
+test(`does not apply new prop keys`, t => {
+  t.plan(1)
+
+  const instance = new YolkBaseComponent(`p`, {height: 5}, [])
+  const node = instance.init()
+
+  const patched = new YolkBaseComponent(`p`, {width: 10}, [`hello`])
+  patched.update(instance)
+
+  t.equal(node.outerHTML, `<p height="null">hello</p>`)
+})
+
+test(`listens for mount and umount when defined`, t => {
+  t.plan(2)
+  t.timeoutAfter(100)
+
+  const instance = new YolkBaseComponent(`p`, {}, [])
+  const node = instance.init()
+
+  node.addEventListener(`mount`, () => {
+    t.pass(`emits mount event`)
+  })
+
+  node.addEventListener(`unmount`, () => {
+    t.pass(`emits unmount event`)
+  })
+
+  // insert it into the `dom` so that mount fires
+  document.body.appendChild(node)
+
+  instance.destroy()
+})

--- a/test/unit/YolkBaseComponent-test.js
+++ b/test/unit/YolkBaseComponent-test.js
@@ -1,4 +1,5 @@
 const test = require(`tape`)
+const Rx = require(`rx`)
 const YolkBaseComponent = require(`YolkBaseComponent`)
 
 test(`returns a base component`, t => {
@@ -41,9 +42,70 @@ test(`listens for mount and umount when defined`, t => {
   node.addEventListener(`unmount`, () => {
     t.pass(`emits unmount event`)
   })
-
-  // insert it into the `dom` so that mount fires
   document.body.appendChild(node)
 
   instance.destroy()
+})
+
+test(`accepts observables as props`, t => {
+  t.plan(2)
+
+  const height = new Rx.BehaviorSubject(5)
+
+  const instance = new YolkBaseComponent(`p`, {height}, [])
+  const node = instance.init()
+  document.body.appendChild(node)
+
+  t.equal(node.outerHTML, `<p height="5"></p>`)
+
+  height.onNext(10)
+
+  t.equal(node.outerHTML, `<p height="10"></p>`)
+})
+
+test(`does not wrap objects with toJS defined on them`, t => {
+  t.plan(1)
+
+  const style = {
+    toJS () {
+      return {height: 5, width: 10}
+    },
+  }
+
+  const instance = new YolkBaseComponent(`p`, {style}, [])
+  const node = instance.init()
+  document.body.appendChild(node)
+
+  t.equal(node.outerHTML, `<p style="height: 5px; width: 10px; "></p>`)
+})
+
+test(`properly wraps children with toJS defined on them`, t => {
+  t.plan(2)
+
+  const child1 = new YolkBaseComponent(`p`, null, `hello`)
+  const child2 = new Rx.BehaviorSubject(new YolkBaseComponent(`p`, null, `goodbye`))
+
+  let children = {
+    toJS () {
+      return [child1]
+    },
+  }
+
+  const childrenSubject = new Rx.BehaviorSubject(children)
+
+  const instance = new YolkBaseComponent(`b`, null, childrenSubject)
+  const node = instance.init()
+  document.body.appendChild(node)
+
+  t.equal(node.outerHTML, `<b><p>hello</p></b>`)
+
+  children = {
+    toJS () {
+      return [child1, child2]
+    },
+  }
+
+  childrenSubject.onNext(children)
+
+  t.equal(node.outerHTML, `<b><p>hello</p><p>goodbye</p></b>`)
 })

--- a/test/unit/transformProperties-test.js
+++ b/test/unit/transformProperties-test.js
@@ -30,5 +30,5 @@ test(`transformProperties: transforms props so that they will work correctly wit
     },
   }
 
-  t.deepEqual(transformProperties(`div`, props), transformedProps)
+  t.deepEqual(transformProperties(props), transformedProps)
 })


### PR DESCRIPTION
The primary motivation here is to make libraries like [ImmutableJS](https://github.com/facebook/immutable-js/) and [Freezer](https://github.com/arqex/freezer) very easy to integrate; though any object with a `toJS` method would receive the same flexibility.

I'm not sure if only checking for `toJS` is good enough here. Do any other libraries use `toJS`?

Checklist:
- [x] If an object has `.toJS` defined on it, do not attempt to wrap it any further than with `Rx.Observable.just`
- [x] In `YolkBaseComponent`, check whether `.toJS` is present on any props or children, and if so, flatMap to `wrapObject(obj.toJS())` (or something).
- [x] Write tests to cover these scenarios.
- [x] Probably just gonna throw in some unit tests too as they're badly needed.
- [ ] Convert the [todo mvc](https://github.com/BrewhouseTeam/yolk-todomvc) app over to using ImmutableJS.
- [x] Add information to the README